### PR TITLE
feat(front): before zkSync launch

### DIFF
--- a/src/components/dapp/Connected.tsx
+++ b/src/components/dapp/Connected.tsx
@@ -9,8 +9,8 @@ export default function Connected({ children, ...props }: ConnectedProps) {
   if (!connected)
     return (
       <Modal title="Connect Wallet" className="mx-auto w-full max-w-[500px]" modal={<WalletConnectors />}>
-        <Button look="hype" size="lg" {...props}>
-          Connect wallet
+        <Button look="hype" size="md" {...props}>
+          Connect
         </Button>
       </Modal>
     );

--- a/src/components/dapp/WalletButton.tsx
+++ b/src/components/dapp/WalletButton.tsx
@@ -42,8 +42,8 @@ export default function WalletButton({ select, connect, status, ...props }: Wall
     return (
       <Modal title="CONNECT WALLET" className="mx-auto w-full max-w-[500px]" modal={<WalletConnectors />}>
         {connect || (
-          <Button look="hype" size="lg" {...props}>
-            Connect wallet
+          <Button look="hype" size="md" {...props}>
+            Connect
           </Button>
         )}
       </Modal>

--- a/src/components/extenders/Card.tsx
+++ b/src/components/extenders/Card.tsx
@@ -8,7 +8,7 @@ import type { ButtonProps } from "../primitives/Button";
 
 export const cardStyles = tv({
   extend: boxStyles,
-  base: "text-main-11 flex !justify-start items-center outline-offset-0 outline-0 text-nowrap font-text font-bold",
+  base: "text-main-11 flex !justify-start items-center outline-offset-0 outline-0 font-text font-bold",
   variants: {
     look: {
       soft: "",


### PR DESCRIPTION
- Remove text-nowrap from cards
- Remove "wallet" from "connect wallet" button (to be synced like other apps (eg: uniswap))